### PR TITLE
割合の勾配テスト

### DIFF
--- a/test/node_modules/.vite/results.json
+++ b/test/node_modules/.vite/results.json
@@ -1,1 +1,1 @@
-{"version":"3.1.2","results":[[":settings.test.js",{"duration":5.5461610000000405,"failed":false}],[":vitest.test.js",{"duration":190.58664900000002,"failed":false}]]}
+{"version":"3.1.2","results":[[":settings.test.js",{"duration":3.627344999999991,"failed":false}],[":vitest.test.js",{"duration":152.286967,"failed":false}]]}

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -51,4 +51,13 @@ describe('settings.js について', () => {
       expect(rs + ra + rb + rc).toBe(1)
     })
   })
+
+  describe('確率の勾配', () => {
+    it('S < A < B < C の順になっている', () => {
+      expect(rs).toBeLessThan(ra)  // rs < ra
+      expect(ra).toBeLessThan(rb)  // ra < rb
+      expect(rb).toBeLessThan(rc)  // rb < rc
+    })
+  })
+
 })


### PR DESCRIPTION
ガチャの「暗黙の仕様」としてSがレアであること
が含まれているけど、それを明確にテストする。
それぞれの値について、不等号
rs < ra < rb < rc
が成立すること。
